### PR TITLE
Make shebang line on .sh scripts more portable

### DIFF
--- a/tarsnap-archive.sh
+++ b/tarsnap-archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Tarsnap backup script
 # Written by Tim Bishop, 2009.

--- a/tarsnap-prune.sh
+++ b/tarsnap-prune.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Tarsnap backup script
 # Written by Tim Bishop, 2009.


### PR DESCRIPTION
* Set shebang line to /usr/bin/env bash so this should work on platforms where bash lives elsewhere within the PATH.

This was the only modification that I needed to make for this to work on a FreeBSD 10.1 system, and it should remain compatible with Linux and other systems.