### PR TITLE
Make path for "test" absolute

### DIFF
--- a/systemd/tarsnap-archive-daily.service
+++ b/systemd/tarsnap-archive-daily.service
@@ -3,4 +3,4 @@ Description=Tarsnap Archive Daily
 
 [Service]
 Type=simple
-ExecStart=test $(date +\%u) -ne 1 && test $(date +\%e) -ne 01 && /usr/local/bin/tarsnap-archive.sh daily
+ExecStart=/usr/bin/test $(date +\%u) -ne 1 && /usr/bin/test $(date +\%e) -ne 01 && /usr/local/bin/tarsnap-archive.sh daily

--- a/systemd/tarsnap-archive-weekly.service
+++ b/systemd/tarsnap-archive-weekly.service
@@ -3,4 +3,4 @@ Description=Tarsnap Archive Weekly
 
 [Service]
 Type=simple
-ExecStart=test $(date +\%u) -eq 1 && test $(date +\%e) -ne 01 && /usr/local/bin/tarsnap-archive.sh weekly
+ExecStart=/usr/bin/test $(date +\%u) -eq 1 && /usr/bin/test $(date +\%e) -ne 01 && /usr/local/bin/tarsnap-archive.sh weekly


### PR DESCRIPTION
Systemd refuses to start unless path is absolute in the current version.
